### PR TITLE
Use higher rate limit Jupiter API

### DIFF
--- a/src/jupiter/swap/swap-helper.ts
+++ b/src/jupiter/swap/swap-helper.ts
@@ -18,7 +18,7 @@ export async function getQuote(
   convertedAmountOfTokenOut: number,
   slippage: any
 ) {
-  const url = `https://quote-api.jup.ag/v6/quote?inputMint=${tokenToSell}&outputMint=${tokenToBuy}&amount=${convertedAmountOfTokenOut}&slippageBps=${slippage}`;
+  const url = `https://public.jupiterapi.com/quote?inputMint=${tokenToSell}&outputMint=${tokenToBuy}&amount=${convertedAmountOfTokenOut}&slippageBps=${slippage}`;
   const response = await fetch(url);
   const quote = await response.json();
   return quote;
@@ -44,7 +44,7 @@ export async function getSwapTransaction(
       dynamicComputeUnitLimit: true, // allow dynamic compute limit instead of max 1,400,000
       prioritizationFeeLamports: 4211970, // prioritization fee
     };
-    const resp = await fetch("https://quote-api.jup.ag/v6/swap", {
+    const resp = await fetch("https://public.jupiterapi.com/swap", {
       method: "POST",
       headers: {
         "Content-Type": "application/json",


### PR DESCRIPTION
This PR adjusts the API provided for the Jupiter API. The default API was updated for swap/quote to leverage [jupiterapi.com](https://www.jupiterapi.com/). The API offers higher rate limits (up to 10 rps) along with a faster updated market cache. The [jupiterapi.com](https://www.jupiterapi.com/) market cache surfaces newly launched tokens faster since it doesn't require a certain volume/liquidity threshold to be met, along with an improved cadence of it being updated. With that said, the API does take a small platform fee (0.2%) on swaps given the stability/rate limits/new markets it provides.

More details can be found on the site.