### PR TITLE
Added missing creator field to token create instruction on pump.fun

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@bloxroute/solana-trader-client-ts": "^2.1.6",
     "@bonfida/spl-name-service": "^2.5.2",
-    "@coral-xyz/anchor": "^0.30.1",
+    "@coral-xyz/anchor": "^0.31.1",
     "@irys/sdk": "^0.2.1",
     "@lightprotocol/compressed-token": "^0.3.4",
     "@lightprotocol/stateless.js": "^0.4.4",

--- a/src/grpc_streaming_dev/grpc-pf-sniper/src/pumpdotfun-sdk/src/IDL/pump-fun.json
+++ b/src/grpc_streaming_dev/grpc-pf-sniper/src/pumpdotfun-sdk/src/IDL/pump-fun.json
@@ -252,6 +252,10 @@
         {
           "name": "uri",
           "type": "string"
+        },
+        {
+          "name": "creator",
+          "type": "pubkey"
         }
       ]
     },

--- a/src/grpc_streaming_dev/grpc-pf-sniper/src/pumpdotfun-sdk/src/IDL/pump-fun.ts
+++ b/src/grpc_streaming_dev/grpc-pf-sniper/src/pumpdotfun-sdk/src/IDL/pump-fun.ts
@@ -231,6 +231,10 @@ export type PumpFun = {
         {
           name: "uri";
           type: "string";
+        },
+        {
+          "name": "creator",
+          "type": "pubkey"
         }
       ];
     },

--- a/src/pumpfunsdk/pumpdotfun-sdk/src/IDL/pump-fun.json
+++ b/src/pumpfunsdk/pumpdotfun-sdk/src/IDL/pump-fun.json
@@ -252,6 +252,10 @@
         {
           "name": "uri",
           "type": "string"
+        },
+        {
+          "name": "creator",
+          "type": "pubkey"
         }
       ]
     },

--- a/src/pumpfunsdk/pumpdotfun-sdk/src/IDL/pump-fun.ts
+++ b/src/pumpfunsdk/pumpdotfun-sdk/src/IDL/pump-fun.ts
@@ -231,6 +231,10 @@ export type PumpFun = {
         {
           name: "uri";
           type: "string";
+        },
+        {
+          "name": "creator",
+          "type": "pubkey"
         }
       ];
     },

--- a/src/pumpfunsdk/pumpdotfun-sdk/src/pumpfun.ts
+++ b/src/pumpfunsdk/pumpdotfun-sdk/src/pumpfun.ts
@@ -267,7 +267,7 @@ export class PumpFunSDK {
     );
 
     return this.program.methods
-      .create(name, symbol, uri)
+      .create(name, symbol, uri, creator)
       .accounts({
         mint: mint.publicKey,
         associatedBondingCurve: associatedBondingCurve,


### PR DESCRIPTION
There is a new field required to create pump.fun tokens:
https://github.com/rckprtr/pumpdotfun-sdk/commit/4afb582bf0821c71ad8cdd0c78395e634c76688d
I've added this field to the IDL